### PR TITLE
PACM-1308 #time 5m - Graceful handling if getallheaders isn't available

### DIFF
--- a/src/Recorder/OpenTracingRecorder.php
+++ b/src/Recorder/OpenTracingRecorder.php
@@ -26,10 +26,13 @@ class OpenTracingRecorder implements FlowRecorder
         }
         $this->tracer = $tracer;
 
+        // fallback to empty array if getallheaders() isn't available
+        $headers = function_exists('getallheaders') ? getallheaders() : [];
+
         // extract the span context
         $spanContext = $this->tracer->extract(
             Formats\TEXT_MAP,
-            getallheaders()
+            $headers
         );
 
         $scope = $this->tracer->startActiveSpan($spanName, [


### PR DESCRIPTION
This PR includes an update to the `EricPridham\Flow\OpenTracingRecorder` class to have a graceful fallback if the `getallheaders()` function is not defined.

Note: We discovered that in Laravel Vapor, this scenario can come up when the Vapor application bootstraps itself AFTER a re-boot cycle (e.g. Vapor attempts to re-boot/re-fresh [after a given number of invocations](https://github.com/laravel/vapor-core/blob/2.0/stubs/fpmRuntime.php#L92-L94)).

More info on the issue can be found[ in this document](https://continued.atlassian.net/wiki/spaces/RW/pages/2683732154/Vapor+Athena+Oracle+HTTP+502+Errors#Takeaways) on Confluence.