### PR TITLE
Truncate the response if it is too large to fit into the table

### DIFF
--- a/tests/Unit/Watchers/QueryWatcherTest.php
+++ b/tests/Unit/Watchers/QueryWatcherTest.php
@@ -26,7 +26,9 @@ class QueryWatcherTest extends FeatureTestCase
         $bindings = ['foo', 'bar'];
         $connection->shouldReceive([
             'prepareBindings' => $bindings,
-            'getName' => 'foo'
+            'getName' => 'foo',
+            'getDriverName' => 'bar',
+            'getDatabaseName' => 'baz',
         ]);
         event(new QueryExecuted('sql', $bindings, 12345, $connection));
 
@@ -34,6 +36,7 @@ class QueryWatcherTest extends FeatureTestCase
             function (string $requestId, QueryPayload $payload) {
                 $this->assertEquals('sql', $payload->data['sql']);
                 $this->assertEquals(['foo', 'bar'], $payload->data['bindings']);
+                $this->assertEquals('baz', $payload->data['database']);
                 return true;
             }
         );

--- a/tests/Unit/Watchers/RequestWatcherTest.php
+++ b/tests/Unit/Watchers/RequestWatcherTest.php
@@ -32,7 +32,9 @@ class RequestWatcherTest extends FeatureTestCase
 
         $response = Mockery::mock(Response::class);
         $response->shouldReceive([
-            'getContent' => json_encode(['response' => true])
+            'getContent' => json_encode(['response' => true]),
+            'getStatusCode' => 200,
+            'isSuccessful' => true,
         ]);
 
         $flow->registerWatchers([new RequestWatcher()]);
@@ -45,6 +47,42 @@ class RequestWatcherTest extends FeatureTestCase
                 $this->assertEquals('method', $payload->data['method']);
                 $this->assertEquals(['foo' => 'bar'], $payload->data['contents']);
                 $this->assertEquals(['response' => true], $payload->data['response']);
+                return true;
+            }
+        );
+    }
+
+    public function test_it_replaces_long_requests(): void
+    {
+        $veryLongResponse = bin2hex(random_bytes(65535));
+
+        $flow = new Flow();
+        $recorder = Mockery::spy(FlowRecorder::class);
+        $flow->registerRecorders([$recorder]);
+
+        $request = \Mockery::mock(Request::class);
+        $request->shouldReceive([
+            'fullUrl' => 'full-url',
+            'method' => 'method',
+            'all' => ['foo' => 'bar'],
+            'is' => false,
+            'server' => 0.0
+        ]);
+
+        $response = Mockery::mock(Response::class);
+        $response->shouldReceive([
+            'getContent' => json_encode(['response' => $veryLongResponse]),
+            'getStatusCode' => 200,
+            'isSuccessful' => true,
+        ]);
+
+        $flow->registerWatchers([new RequestWatcher()]);
+
+        event(new RequestHandled($request, $response));
+
+        $recorder->shouldHaveReceived('record',
+            function (string $requestId, RequestPayload $payload) {
+                $this->assertEquals("Response Too Large", $payload->data['response']);
                 return true;
             }
         );


### PR DESCRIPTION
The size limit for mysql TEXT fields is ~64kb, but we have some requests which exceed that and result in truncated JSON which then prevents any results from coming back when querying an affected range of time for one of these requests.

This PR does two things:

1. Detects if a response body is larger than 64kb and saves "Response Too Large" instead.
2. Since data that is truncated may already exist in the database, this allows other results to appear and prints "Malformed JSON Response" for these events instead.

Feedback welcome