### PR TITLE
chore: PARS-25 Update illuminate/support allowed versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "homepage": "https://github.com/ericpridham/flow",
     "keywords": ["Laravel", "Flow"],
     "require": {
-        "illuminate/support": "~8|~9",
+        "illuminate/support": "^8|^9|^10|^11",
         "ext-json": "*",
         "ralouphie/getallheaders": "^3.0"
     },


### PR DESCRIPTION
`illuminate/support` versions follow the main Laravel version. In order to use this package on our services that run on Laravel 10.x and 11.x we need to allow for those versions of `illuminate/support`.